### PR TITLE
Nested route fix

### DIFF
--- a/client/dist/index.html
+++ b/client/dist/index.html
@@ -1,16 +1,19 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"/>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons"/>
-    <title>ZAP</title>
-    <link rel="stylesheet" type="text/css" href="../style.css">
-  </head>
-  <body>
-    <div id="root"></div>
-    <script src="./bundle.js"></script>
-  </body>
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
+  <title>ZAP</title>
+  <link rel="stylesheet" type="text/css" href="../style.css">
+</head>
+
+<body>
+  <div id="root"></div>
+  <script src="/bundle.js"></script>
+</body>
+
 </html>

--- a/server/index.js
+++ b/server/index.js
@@ -9,11 +9,7 @@ app.use(express.urlencoded({ extended: true }));
 
 app.use(express.static(path.resolve(__dirname, '../client/dist')));
 
-app.get('/bundle', (req, res) => {
-  res.sendFile(path.resolve(__dirname, '../client/dist/bundle.js'));
-});
-
-app.get('/*', (req, res) => {
+app.get('*', (req, res) => {
   res.sendFile(path.resolve(__dirname, '../client/dist/index.html'));
 });
 

--- a/server/index.js
+++ b/server/index.js
@@ -9,7 +9,11 @@ app.use(express.urlencoded({ extended: true }));
 
 app.use(express.static(path.resolve(__dirname, '../client/dist')));
 
-app.get('*', (req, res) => {
+app.get('/bundle', (req, res) => {
+  res.sendFile(path.resolve(__dirname, '../client/dist/bundle.js'));
+});
+
+app.get('/*', (req, res) => {
   res.sendFile(path.resolve(__dirname, '../client/dist/index.html'));
 });
 


### PR DESCRIPTION
This is a fix for issue #20

# Changes

 - modified the script tag in our index to /bundle.js from ./bundle.js

Refreshing or loading nested id pages now works correctly. 