### PR TITLE
Updated button and editor component to allow for new tracks

### DIFF
--- a/client/src/components/Editor.jsx
+++ b/client/src/components/Editor.jsx
@@ -33,21 +33,23 @@ export default function Editor() {
   }
 
   useEffect(() => {
-    getTrackData(trackId)
-      .then(data => {
-        console.log('Track Data', data)
-        return getTrackUrls(data)
-      })
-      .then(trackWithUrls => {
-        let layers = []
-        for (var layer in trackWithUrls.layers) {
-          layers.push(trackWithUrls.layers[layer])
-        }
-        setAudioLayers(layers)
-      })
-      .catch(error => {
-        snackbar.showMessage(<Alert variant='error'>There was an error getting your track</Alert>)
-      })
+    if (trackId) { // if trackID is undefined, this will just open a blank editor (for a new track)
+      getTrackData(trackId)
+        .then(data => {
+          console.log('Track Data', data)
+          return getTrackUrls(data)
+        })
+        .then(trackWithUrls => {
+          let layers = []
+          for (var layer in trackWithUrls.layers) {
+            layers.push(trackWithUrls.layers[layer])
+          }
+          setAudioLayers(layers)
+        })
+        .catch(error => {
+          snackbar.showMessage(<Alert variant='error'>There was an error getting your track</Alert>)
+        })
+    }
   }, [])
 
   const importHandler = () => {

--- a/client/src/components/ResponsiveHeader.jsx
+++ b/client/src/components/ResponsiveHeader.jsx
@@ -80,11 +80,11 @@ const ResponsiveHeader = () =>{
   if (pathname === '/dashboard') {
     pages = ['Home', 'Your Tracks'];
   } else if (pathname === '/' && user) {
-    pages = ['Your Tracks', 'Editor'];
+    pages = ['Your Tracks', 'New Track'];
   } else if (pathname === '/') {
     pages = [];
   } else if (pathname === '/tracks' && user) {
-    pages = ['Home', 'Editor'];
+    pages = ['Home', 'New Track'];
   } else {
     pages = ['Home'];
   }
@@ -112,7 +112,7 @@ const ResponsiveHeader = () =>{
     if (target === 'Your Tracks') {
       navigate("/dashboard")
     }
-    if (target === 'Editor') {
+    if (target === 'New Track') {
       navigate("/edit")
     }
   };

--- a/client/src/components/ResponsiveHeader.jsx
+++ b/client/src/components/ResponsiveHeader.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext} from "react";
+import React, { useState, useContext } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import UserContext from '../context/UserContext.js';
 import { auth } from '../lib/firebase.js';
@@ -64,7 +64,7 @@ const StyledInputBase = styled(InputBase)(({ theme }) => ({
 }));
 
 
-const ResponsiveHeader = () =>{
+const ResponsiveHeader = () => {
   /*
   LOGIC FOR WHAT OPTIONS TO OFFER BASED ON USER STATUS AND CURRENT PAGE
   */
@@ -78,13 +78,13 @@ const ResponsiveHeader = () =>{
     settings = ['Log In'];
   }
   if (pathname === '/dashboard') {
-    pages = ['Home', 'Your Tracks'];
+    pages = ['Home', 'New Track'];
   } else if (pathname === '/' && user) {
     pages = ['Your Tracks', 'New Track'];
   } else if (pathname === '/') {
     pages = [];
-  } else if (pathname === '/tracks' && user) {
-    pages = ['Home', 'New Track'];
+  } else if (pathname.includes('/edit') && user) {
+    pages = ['Home', 'New Track', 'Your Tracks'];
   } else {
     pages = ['Home'];
   }
@@ -197,7 +197,7 @@ const ResponsiveHeader = () =>{
               <StyledInputBase
                 placeholder="Search…"
                 inputProps={{ 'aria-label': 'search' }}
-                />
+              />
             </Search>
           </Box>
           <Box sx={{ flexGrow: 0 }}>

--- a/client/src/components/app.jsx
+++ b/client/src/components/app.jsx
@@ -26,6 +26,7 @@ export default function App() {
             <Route path="/" element={<Home />} />
             <Route path='login' element={<Entry />} />
             <Route path='edit/:trackId' element={<Editor />} />
+            <Route path='edit' element={<Editor />} />
             <Route path='dashboard' element={
               <RequireAuth>
                 <Dashboard />
@@ -37,6 +38,5 @@ export default function App() {
         </div>
       </UserContext.Provider>
     </SnackbarProvider>
-
   );
 }


### PR DESCRIPTION
This allows the user to use the same edit page without providing a track id. They will now be able to record a new track.

Note: selecting the tracks from the dashboard will still open the editor correctly.