### PR TITLE
Player classes trim

### DIFF
--- a/client/src/components/LayerEditor.jsx
+++ b/client/src/components/LayerEditor.jsx
@@ -23,7 +23,7 @@ export default function LayerEditorCopy({ id }) {
   const [duration, setDuration] = useState(false);
   const [pitchSliderValue, setPitchSliderValue] = useState(player._pitch);
   const [volumeSliderValue, setVolumeSliderValue] = useState(player._volume);
-  const [trimFromStart,setTrimFromStart] =useState(player.trimFromStart)
+  const [trimFromStart, setTrimFromStart] = useState(player.trimFromStart);
   // const pitchShift = props.pitchShift;
   // const layerVolume = props.layerVolume;
   // const solo = props.solo;
@@ -74,11 +74,14 @@ export default function LayerEditorCopy({ id }) {
     setIsSolo(player._solo);
   };
   const trimFromStartTime = (event, newValue) => {
-  setTrimFromStart(newValue)
-    player.changeTrimFromStart(newValue)
-      // props.start = newValue
+    setTrimFromStart(newValue);
+    player.changeTrimFromStart(newValue);
+    // props.start = newValue
+  };
+  const testing = () => {
 
-    }
+    player.start()
+  };
   // editor modal handlers
   const [editOpen, setEditOpen] = React.useState(false);
   const layerEditorOpen = () => {
@@ -168,6 +171,7 @@ export default function LayerEditorCopy({ id }) {
             aria-label='Trim Slider'
             valueLabelDisplay='auto'
           />
+          <Button onClick={testing}>DO you work </Button>
         </Box>
       </Modal>
     </>

--- a/client/src/components/LayerEditor.jsx
+++ b/client/src/components/LayerEditor.jsx
@@ -75,7 +75,7 @@ export default function LayerEditorCopy({ id }) {
   };
   const trimFromStartTime = (event, newValue) => {
   setTrimFromStart(newValue)
-
+    player.changeTrimFromStart(newValue)
       // props.start = newValue
 
     }
@@ -159,7 +159,7 @@ export default function LayerEditorCopy({ id }) {
             aria-label='Pitch Slider'
             valueLabelDisplay='auto'
           />
-          <Typography>trimFromStart Audio</Typography>
+          <Typography>Trim From Start</Typography>
           <Slider
             min={0}
             max={50}

--- a/client/src/components/LayerEditor.jsx
+++ b/client/src/components/LayerEditor.jsx
@@ -8,21 +8,22 @@ import FormControlLabel from '@mui/material/FormControlLabel';
 import Modal from '@mui/material/Modal';
 import Slider from '@mui/material/Slider';
 import Typography from '@mui/material/Box';
-import { usePlayerStore } from '../context/PlayerContext.js'
+import { usePlayerStore } from '../context/PlayerContext.js';
 import { updatePlayerProperty } from '../lib/playerTableReducer.js';
 
 import TimeControlButton from './editorComponents/TimeControlButton.jsx';
 
 export default function LayerEditorCopy({ id }) {
-  const [playerStore, dispatch] = usePlayerStore()
+  const [playerStore, dispatch] = usePlayerStore();
   // const { player, waveform, pitch, volume, solo, pitchShift, layerVolume, layerData } = playerStore.allPlayers[props.id]
-  const player = playerStore.allPlayers[id]
+  const player = playerStore.allPlayers[id];
   // const waveform = props.waveform;
   const [isSolo, setIsSolo] = useState(player._solo);
   const [isMuted, setIsMuted] = useState(player._mute);
   const [duration, setDuration] = useState(false);
   const [pitchSliderValue, setPitchSliderValue] = useState(player._pitch);
   const [volumeSliderValue, setVolumeSliderValue] = useState(player._volume);
+  const [trimFromStart,setTrimFromStart] =useState(player.trimFromStart)
   // const pitchShift = props.pitchShift;
   // const layerVolume = props.layerVolume;
   // const solo = props.solo;
@@ -43,19 +44,19 @@ export default function LayerEditorCopy({ id }) {
   }, [duration]);
 
   const changeVolumeValue = (event, newValue) => {
-    newValue = Math.round(newValue)
-    setVolumeSliderValue(newValue)
-    player.changeVolumeValue(newValue)
+    newValue = Math.round(newValue);
+    setVolumeSliderValue(newValue);
+    player.changeVolumeValue(newValue);
   };
 
   const changePitchValue = (event, newValue) => {
-    newValue = Math.round(newValue)
+    newValue = Math.round(newValue);
     setPitchSliderValue(newValue);
-    player.changePitchValue(newValue)
+    player.changePitchValue(newValue);
   };
 
   const muteLayer = () => {
-    player.toggleMute()
+    player.toggleMute();
     setIsMuted(player._mute);
   };
 
@@ -69,10 +70,15 @@ export default function LayerEditorCopy({ id }) {
   // };
 
   const soloLayer = () => {
-    player.toggleSolo()
+    player.toggleSolo();
     setIsSolo(player._solo);
   };
+  const trimFromStartTime = (event, newValue) => {
+  setTrimFromStart(newValue)
 
+      // props.start = newValue
+
+    }
   // editor modal handlers
   const [editOpen, setEditOpen] = React.useState(false);
   const layerEditorOpen = () => {
@@ -151,6 +157,15 @@ export default function LayerEditorCopy({ id }) {
             value={pitchSliderValue}
             onChange={changePitchValue}
             aria-label='Pitch Slider'
+            valueLabelDisplay='auto'
+          />
+          <Typography>trimFromStart Audio</Typography>
+          <Slider
+            min={0}
+            max={50}
+            value={trimFromStart}
+            onChange={trimFromStartTime}
+            aria-label='Trim Slider'
             valueLabelDisplay='auto'
           />
         </Box>

--- a/client/src/components/LayerPlayer.jsx
+++ b/client/src/components/LayerPlayer.jsx
@@ -31,15 +31,15 @@ export default function LayerPlayer({ layers, trackId, userId, recordingHandler,
 
       let keys = Object.keys(playerStore.allPlayers)
       keys.forEach((layerKey, i) => {
-
+        let layer = playerStore.allPlayers[layerKey]
         Tone.Transport.schedule((time) => {
           Tone.Draw.schedule(() => {
             renderWaveform(layer.waveform, layerKey);
           }, time);
         }, "+0.005");
-        let layer = playerStore.allPlayers[layerKey]
+
         console.log('LAYER',layer.trimFromStart)
-        layer.start((layer.trimFromStart),layer.trimFromStart,layer.layerData.duration)
+        layer.start((layer.trimFromStart),layer.trimFromStart,layer.duration())
         // layer.player.sync().start()
       });
 

--- a/client/src/lib/player.js
+++ b/client/src/lib/player.js
@@ -2,7 +2,7 @@ import { duration } from '@mui/material';
 import * as Tone from 'tone';
 
 export class Layer {
-  constructor({ url, volume, pitch, id, layerData }) {
+  constructor({ url, volume, pitch, id, layerData, trimFromStart }) {
     this.id = id;
     this.url = url;
     this.player = new Tone.Player(this.url);
@@ -13,7 +13,7 @@ export class Layer {
     this.layerData = layerData;
     this.name = getLayerName(this.layerData);
 
-    this.trimFromStart = this.layerData.trimFromStart || 0;
+    this.trimFromStart = trimFromStart || 0;
     this._pitch = this.pitchShift.pitch;
     this._mute = false;
     this._solo = false;

--- a/client/src/lib/player.js
+++ b/client/src/lib/player.js
@@ -1,3 +1,4 @@
+import { duration } from '@mui/material';
 import * as Tone from 'tone';
 
 export class Layer {
@@ -12,7 +13,7 @@ export class Layer {
     this.layerData = layerData;
     this.name = getLayerName(this.layerData);
 
-    this.trimFromStart = this.trimFromStart || 0;
+    this.trimFromStart = this.layerData.trimFromStart || 0;
     this._pitch = this.pitchShift.pitch;
     this._mute = false;
     this._solo = false;
@@ -47,6 +48,10 @@ export class Layer {
     this._solo = this.solo.solo;
   }
 
+  changeTrimFromStart(newValue){
+    this.trimFromStart = newValue
+  }
+
   changePitchValue(newValue) {
     this.pitchShift.pitch = newValue;
   }
@@ -67,9 +72,10 @@ export class Layer {
       fileName: this.layerData.fileName,
       layerName: this.name,
       parent: this.layerData.parent,
+      trimFromStart: this.trimFromStart,
       start: 0,
       end: 0,
-      duration: 0,
+      duration: this.duration(),
     };
   }
 }

--- a/client/src/lib/player.js
+++ b/client/src/lib/player.js
@@ -32,9 +32,12 @@ export class Layer {
     this.player.stop();
   }
 
-  start() {
-    this.player.sync().stop();
-    this.player.sync().start();
+  start(time, offset, duration) {
+    // changed this to just unsync() , no need to stop it again unless you want individual functionality
+    // inwhich case put it back in.
+    // havnt done offset yet, just handling case of trimming  from audio and wanting it to start at the same spot.
+    this.player.unsync()
+    this.player.sync().start(time, time).stop(duration);
   }
 
   toggleMute() {
@@ -48,8 +51,8 @@ export class Layer {
     this._solo = this.solo.solo;
   }
 
-  changeTrimFromStart(newValue){
-    this.trimFromStart = newValue
+  changeTrimFromStart(newValue) {
+    this.trimFromStart = newValue;
   }
 
   changePitchValue(newValue) {

--- a/client/src/lib/player.js
+++ b/client/src/lib/player.js
@@ -1,61 +1,62 @@
-import * as Tone from 'tone'
+import * as Tone from 'tone';
 
 export class Layer {
   constructor({ url, volume, pitch, id, layerData }) {
     this.id = id;
     this.url = url;
-    this.player = new Tone.Player(this.url)
+    this.player = new Tone.Player(this.url);
     this.volume = new Tone.Volume(volume || -5);
-    this.pitchShift = new Tone.PitchShift(pitch || 0)
+    this.pitchShift = new Tone.PitchShift(pitch || 0);
     this.waveform = new Tone.Waveform();
     this.solo = new Tone.Solo().toDestination();
-    this.layerData = layerData
-    this.name = getLayerName(this.layerData)
+    this.layerData = layerData;
+    this.name = getLayerName(this.layerData);
 
-    this._pitch = this.pitchShift.pitch
-    this._mute = false
-    this._solo = false
-    this._volume = this.volume.volume.value
+    this.trimFromStart = this.trimFromStart || 0;
+    this._pitch = this.pitchShift.pitch;
+    this._mute = false;
+    this._solo = false;
+    this._volume = this.volume.volume.value;
   }
 
   connect() {
-    this.player.connect(this.volume)
-    this.player.connect(this.waveform)
-    this.volume.connect(this.pitchShift)
-    this.pitchShift.connect(this.solo)
+    this.player.connect(this.volume);
+    this.player.connect(this.waveform);
+    this.volume.connect(this.pitchShift);
+    this.pitchShift.connect(this.solo);
   }
 
   stop() {
     this.player.unsync();
-    this.player.stop()
+    this.player.stop();
   }
 
   start() {
-    this.player.sync().stop()
-    this.player.sync().start()
+    this.player.sync().stop();
+    this.player.sync().start();
   }
 
   toggleMute() {
-    this.player.mute = !this.player.mute
-    this._mute = this.player.mute
-    console.log('sneaky click', this._mute)
+    this.player.mute = !this.player.mute;
+    this._mute = this.player.mute;
+    console.log('sneaky click', this._mute);
   }
 
   toggleSolo() {
     this.solo.solo = !this.solo.solo;
-    this._solo = this.solo.solo
+    this._solo = this.solo.solo;
   }
 
-  changePitchValue (newValue) {
+  changePitchValue(newValue) {
     this.pitchShift.pitch = newValue;
-  };
+  }
 
-  changeVolumeValue (newValue) {
+  changeVolumeValue(newValue) {
     this.volume.volume.value = newValue;
-  };
+  }
 
   duration() {
-    return this.player._buffer.duration
+    return this.player._buffer.duration;
   }
 
   getLayerData() {
@@ -69,24 +70,22 @@ export class Layer {
       start: 0,
       end: 0,
       duration: 0,
-    }
+    };
   }
-
 }
 
 function getLayerName(layerData) {
-
   if (layerData.fileName.includes('.webm')) {
-    return layerData.fileName.split('.webm')[0]
+    return layerData.fileName.split('.webm')[0];
   }
 
   if (layerData.fileName.includes('.mp3')) {
-    return layerData.fileName.split('.mp3')[0]
+    return layerData.fileName.split('.mp3')[0];
   }
 
   if (layerData?.layerName) {
-    return layerData.layerName
+    return layerData.layerName;
   }
 
-  return 'unknown'
+  return 'unknown';
 }


### PR DESCRIPTION
Got basic trim working. Did some Refactoring/ moving stuff in  


Changes 
1. Moved Tone.Transport.start to the bottom of the function after all the players start functions are called. Think of the individual players  start()  like " arming" them for playing. As soon as transport starts, they'll play 
2.  set Tone.Transport.seconds to = 0 before every play. This prevents having to use Tone.Transport.now() or immediate because the playhead gets reset to 0 before every play.
3. The above also fixes a bug where  you could not press play again until you hit stop, even if the audio was over. 
4. Changed player.js start function to accept time, offset and duration params and chained stop to the end of it with duration fed in , which automatically syncs it to the transport. 
5. removed the stop call from Player.js  start function and called unsync() insted. sync will just create a new instance of the player being synced to the transport, which gets really loud after awhile. If we want to maintain individual control, we just have to put that stop button back in there and add some  conditionals about whether or not  parameters are being fed in 
6. Basic trim from beginning working. Changed  Player.Js  and LayerEditor to reflect, adding functions and MUI components + change handlers. 
7. Also got duration set on each track on save, even though this can probably be done better.  
8. Moved the layer.start( ) invocation beneath the renderWaveform function, though I doubt its doing anything. 

Maybe missed some other stuff , let me know. 

Love the redesign, easier to use and way cleaner code.  


TODO 

Figure out offset and cutting + logic to  trim from both beginning and end. May have to write conditional logic for this as stop is being called with the duration. 

Joe 


-