### PR TITLE
Editor Routing Bug Fix

### DIFF
--- a/client/src/components/Editor.jsx
+++ b/client/src/components/Editor.jsx
@@ -16,11 +16,11 @@ import { getTrackUrls } from "../utils/storage";
 import UserContext from "../context/UserContext";
 import UploadFile from "./UploadFile.jsx";
 
-import { LayerStoreProvider } from "../context/LayerContext.js";
-import { initialState, layerTableReducer } from "../lib/layerTableReducer.js";
+import { addLayer, removeLayer } from '../lib/layerTableReducer.js';
+import { useLayerStore } from '../context/LayerContext.js'
 
 export default function Editor() {
-
+  const [layerStore, dispatch] = useLayerStore();
   const [importModalState, setImportModalState] = useState(false);
   const [recordingModalState, setRecordingModalState] = useState(false);
   const [uploadModalState, setUploadModalState] = useState(false);
@@ -59,7 +59,19 @@ export default function Editor() {
           snackbar.showMessage(<Alert variant='error'>There was an error getting your track</Alert>)
         })
     }
-  }, [])
+
+    if (trackId === undefined) {
+      if (audioLayers?.length > 0) {
+        setAudioLayers([])
+      }
+      let keys = Object.keys(layerStore.allLayers)
+      if (keys.length > 0) {
+        for (var key in keys) {
+          dispatch(removeLayer(key))
+        }
+      }
+    }
+  }, [trackId])
 
   const importHandler = () => {
     setImportModalState(true);
@@ -74,45 +86,40 @@ export default function Editor() {
 
   return (
 
-    <LayerStoreProvider initialState={initialState} reducer={layerTableReducer}>
-      <Container sx={{
-        border: 1,
-        maxHeight: '90vh',
-        minHeight: { xs: '100%', md: '70%' },
-        width: { xs: '100%', md: '70%' },
-        display: 'grid',
-        gridTemplateColumns: { xs: '3fr 2fr', md: '1fr 6fr' },
-        gridTemplateRows: { xs: '5fr 1fr', md: '6fr 1fr' }
-      }}>
+    <Container sx={{
+      border: 1,
+      maxHeight: '90vh',
+      minHeight: { xs: '100%', md: '70%' },
+      width: { xs: '100%', md: '70%' },
+      display: 'grid',
+      gridTemplateColumns: { xs: '3fr 2fr', md: '1fr 6fr' },
+      gridTemplateRows: { xs: '5fr 1fr', md: '6fr 1fr' }
+    }}>
+      <LayerPlayer
+        layers={audioLayers}
+        userId={userData?.user?.uid}
+        trackId={trackId}
+        recordingHandler={recordingHandler}
+        importHandler={importHandler}
+        uploadHandler={uploadHandler}
+      />
 
-        <LayerPlayer
-          layers={audioLayers}
-          userId={userData?.user?.uid}
-          trackId={trackId}
-          recordingHandler={recordingHandler}
-          importHandler={importHandler}
-          uploadHandler={uploadHandler}
-        />
+      <Modal open={importModalState} onClose={handleImportClose}>
+        <Box sx={{ backgroundColor: 'white', top: 50, maxHeight: '100vh', overflow: 'auto' }}>
+          <ImportAduio userId={userData?.user?.uid} currentList={audioLayers} setParentLayers={setAudioLayers} close={handleImportClose} />
+        </Box>
+      </Modal>
+      <Modal open={recordingModalState} onClose={handleRecorderClose} >
+        <Box sx={{ backgroundColor: 'white', margin: 'auto', top: 50, }}>
+          <Recorder currentList={audioLayers} setAudioLayers={setAudioLayers} />
+        </Box>
+      </Modal>
+      <Modal open={uploadModalState} onClose={handleUploadClose} >
+        <Box sx={{ backgroundColor: 'white', margin: 'auto', top: 50, }}>
+          <UploadFile />
+        </Box>
+      </Modal>
+    </Container>
 
-        <Modal open={importModalState} onClose={handleImportClose}>
-          <Box sx={{ backgroundColor: 'white', top: 50, maxHeight: '100vh', overflow: 'auto' }}>
-            <ImportAduio userId={userData?.user?.uid} currentList={audioLayers} setParentLayers={setAudioLayers} close={handleImportClose} />
-          </Box>
-        </Modal>
-        <Modal open={recordingModalState} onClose={handleRecorderClose} >
-          <Box sx={{ backgroundColor: 'white', margin: 'auto', top: 50, }}>
-            <Recorder currentList={audioLayers} setAudioLayers={setAudioLayers} />
-          </Box>
-        </Modal>
-        <Modal open={uploadModalState} onClose={handleUploadClose} >
-          <Box sx={{ backgroundColor: 'white', margin: 'auto', top: 50, }}>
-            <UploadFile />
-          </Box>
-        </Modal>
-      </Container>
-    </LayerStoreProvider>
   )
 }
-
-/* <Button variant="outlined" onClick={() => {setRecordingModalState(true)}}>Record New Layer</Button> */
-/* <Button variant="outlined" onClick={() => {setImportModalState(true)}}>Import Audio Layers</Button> */

--- a/client/src/components/Editor.jsx
+++ b/client/src/components/Editor.jsx
@@ -66,6 +66,7 @@ export default function Editor() {
     }
 
     if (trackId === undefined) {
+      setTrackMetadata({})
       if (audioLayers?.length > 0) {
         setAudioLayers([])
       }
@@ -104,6 +105,7 @@ export default function Editor() {
         layers={audioLayers}
         userId={userData?.user?.uid}
         trackId={trackId}
+        trackMetadata={trackMetadata}
         recordingHandler={recordingHandler}
         updateMetadata={setTrackMetadata}
         importHandler={importHandler}

--- a/client/src/components/Recorder.jsx
+++ b/client/src/components/Recorder.jsx
@@ -92,7 +92,7 @@ export default function RecorderTone({ currentList, setAudioLayers }) {
   return (
     <>
     <Typography variant='h3'>Recorder Component</Typography>
-    <Button variant='outlined' onClick={startRecorder} startIcon={<MicIcon />} disabled={isFinished === false && micRecorder}>Click to record</Button>
+    <Button variant='outlined' onClick={startRecorder} startIcon={<MicIcon />} disabled={isFinished === false && !!micRecorder}>Click to record</Button>
     <Button variant='outlined' onClick={stopRecorder} endIcon={<StopCircleIcon />} disabled={isFinished === true || !micRecorder}>Click to stop</Button>
     <ValidatorForm onSubmit={handleUploadClick}>
       <TextValidator

--- a/client/src/components/app.jsx
+++ b/client/src/components/app.jsx
@@ -4,6 +4,8 @@ import { Routes, Route, Link } from "react-router-dom";
 import UserContext from '../context/UserContext.js';
 import useUserData from '../hooks/useUserData.js';
 import { SnackbarProvider } from 'material-ui-snackbar-provider'
+import { LayerStoreProvider } from "../context/LayerContext.js";
+import { initialState, layerTableReducer } from "../lib/layerTableReducer.js";
 
 import Home from "./Home.jsx";
 import NotFound from './NotFound.jsx'
@@ -19,22 +21,26 @@ export default function App() {
   return (
     <SnackbarProvider SnackbarProps={{ autoHideDuration: 4000 }}>
       <UserContext.Provider value={userData}>
-        <div className="App">
-          <ResponsiveHeader />
-          <Routes>
-            <Route path="/" element={<Home />} />
-            <Route path='login' element={<Entry />} />
-            <Route path='edit/:trackId' element={<Editor />} />
-            <Route path='edit' element={<Editor />} />
-            <Route path='dashboard' element={
-              <RequireAuth>
-                <Dashboard />
-              </RequireAuth>
-            } />
-            <Route path='*' element={<NotFound />} />
-          </Routes>
-        </div>
+        <LayerStoreProvider initialState={initialState} reducer={layerTableReducer}>
+          <div className="App">
+            <ResponsiveHeader />
+            <Routes>
+              <Route path="/" element={<Home />} />
+              <Route path='login' element={<Entry />} />
+              <Route path='edit/:trackId' element={<Editor />} />
+              <Route path='edit' element={
+                <Editor />
+              } />
+              <Route path='dashboard' element={
+                <RequireAuth>
+                  <Dashboard />
+                </RequireAuth>
+              } />
+              <Route path='*' element={<NotFound />} />
+            </Routes>
+          </div>
+        </LayerStoreProvider>
       </UserContext.Provider>
-    </SnackbarProvider>
+    </SnackbarProvider >
   );
 }


### PR DESCRIPTION
# Editor Routing Fix. 
This is a bug fix for when you try and open a new blank track while another is still open. 
To fix this issue, I have a cleanup task running now whenever the trackId becomes undefined. 
This could be a little more precise to if the trackId changes to something different but since we are not making that available to the use without something like them pasting a url(Which causes a refresh so we don't really care)

Possibly needs to be revisited but I think this is more than enough for now. 

# Changes
 - Added access to layerStore inside Editor.jsx
 - Updated onMount useEffect to fire on every trackId update instead.
 - Added new condition to trackId useEffect to clear all data if the trackId changes