### PR TITLE
Refactor volume slider

### DIFF
--- a/client/src/components/LayerEditor.jsx
+++ b/client/src/components/LayerEditor.jsx
@@ -206,8 +206,8 @@ export default function LayerEditorCopy({ id, player }) {
           </Typography>
           <Typography>Volume</Typography>
           <Slider
-            min={-20}
-            max={20}
+            min={-40}
+            max={5}
             value={volumeSliderValue}
             onChange={changeVolumeValue}
             aria-label='Volume Slider'

--- a/client/src/components/LayerEditor.jsx
+++ b/client/src/components/LayerEditor.jsx
@@ -19,7 +19,9 @@ export default function LayerEditorCopy({ id, player }) {
   const [isSolo, setIsSolo] = useState(player._solo);
   const [isMuted, setIsMuted] = useState(player._mute);
   const [duration, setDuration] = useState(false);
-  const [volumeSliderValue, setVolumeSliderValue] = useState(Math.round(player._volume));
+  const [volumeSliderValue, setVolumeSliderValue] = useState(
+    Math.abs(Math.round( -40 - player._volume))
+  );
   const [trimFromStart, setTrimFromStart] = useState(player.trimFromStart);
   const [trimFromEnd, setTrimFromEnd] = useState(player.trimFromEnd);
   const [playerPlaybackRate, setPlayerPlaybackRate] = useState(
@@ -48,9 +50,8 @@ export default function LayerEditorCopy({ id, player }) {
   const changeVolumeValue = (event, newValue) => {
     newValue = Math.round(newValue);
     setVolumeSliderValue(newValue);
-    player.changeVolumeValue(newValue);
+    player.changeVolumeValue(-40 + newValue);
   };
-
 
   const muteLayer = () => {
     player.toggleMute();
@@ -204,10 +205,17 @@ export default function LayerEditorCopy({ id, player }) {
           <Typography variant='subtitle2' id='modal-edit-title'>
             Edit Layer: {player.name}
           </Typography>
-          <Typography>Volume</Typography>
+          <Typography>
+            Volume:{' '}
+            {volumeSliderValue === 40
+              ? 'Max'
+              : volumeSliderValue === 0
+              ? 'Min'
+              : volumeSliderValue}
+          </Typography>
           <Slider
-            min={-40}
-            max={5}
+            min={0}
+            max={40}
             value={volumeSliderValue}
             onChange={changeVolumeValue}
             aria-label='Volume Slider'

--- a/client/src/components/LayerEditor.jsx
+++ b/client/src/components/LayerEditor.jsx
@@ -19,8 +19,7 @@ export default function LayerEditorCopy({ id, player }) {
   const [isSolo, setIsSolo] = useState(player._solo);
   const [isMuted, setIsMuted] = useState(player._mute);
   const [duration, setDuration] = useState(false);
-  const [pitchSliderValue, setPitchSliderValue] = useState(player._pitch);
-  const [volumeSliderValue, setVolumeSliderValue] = useState(player._volume);
+  const [volumeSliderValue, setVolumeSliderValue] = useState(Math.round(player._volume));
   const [trimFromStart, setTrimFromStart] = useState(player.trimFromStart);
   const [trimFromEnd, setTrimFromEnd] = useState(player.trimFromEnd);
   const [playerPlaybackRate, setPlayerPlaybackRate] = useState(
@@ -29,7 +28,7 @@ export default function LayerEditorCopy({ id, player }) {
 
   const [playerGrain, setPlayerGrain] = useState(player.player.grainSize);
   const [playerOverlap, setPlayerOverlap] = useState(player.player.overlap);
-  const [playerDetune, setPlayerDetune] = useState(player.player.detune);
+  const [playerDetune, setPlayerDetune] = useState(player.player.detune / 100);
 
   // put page on mousedown listener to get the duration of tracks then immediatly remove it after setting each tracks duration.
   useEffect(() => {
@@ -52,11 +51,6 @@ export default function LayerEditorCopy({ id, player }) {
     player.changeVolumeValue(newValue);
   };
 
-  const changePitchValue = (event, newValue) => {
-    newValue = Math.round(newValue);
-    setPitchSliderValue(newValue);
-    player.changePitchValue(newValue);
-  };
 
   const muteLayer = () => {
     player.toggleMute();
@@ -68,7 +62,6 @@ export default function LayerEditorCopy({ id, player }) {
     setIsSolo(player._solo);
   };
   const trimFromStartTime = (event, newValue) => {
-    // newValue = Number(newValue)
     newValue = Number.parseFloat(newValue).toFixed(2);
     newValue = Number(newValue);
     setTrimFromStart(newValue);
@@ -220,13 +213,13 @@ export default function LayerEditorCopy({ id, player }) {
             aria-label='Volume Slider'
             valueLabelDisplay='auto'
           />
-          <Typography>Pitch</Typography>
+          <Typography> Pitch {playerDetune} </Typography>
           <Slider
             min={-12}
             max={12}
-            value={pitchSliderValue}
-            onChange={changePitchValue}
-            aria-label='Pitch Slider'
+            value={playerDetune}
+            onChange={changeDetune}
+            aria-label='Trim Slider'
             valueLabelDisplay='auto'
           />
 
@@ -288,15 +281,6 @@ export default function LayerEditorCopy({ id, player }) {
             value={playerOverlap}>
             +Overlap Size
           </Button>
-          <Typography> Detune {playerDetune} </Typography>
-          <Slider
-            min={-12}
-            max={12}
-            value={playerDetune}
-            onChange={changeDetune}
-            aria-label='Trim Slider'
-            valueLabelDisplay='auto'
-          />
         </Box>
       </Modal>
     </>

--- a/client/src/components/LayerPlayer.jsx
+++ b/client/src/components/LayerPlayer.jsx
@@ -36,12 +36,12 @@ export default function LayerPlayer({
   const playerRef = useRef(layerStore.player);
   const [allLayersLoaded, setAllLayersLoaded] = useState(false);
   const [globalPitch, setGlobalPitch] = useState(0);
-  const [globalVolume, setGlobalVolume] = useState(-20)
+  const [globalVolume, setGlobalVolume] = useState(20)
   const [globalPlayback,setGlobalPlayback] = useState(1)
 
   const playAllLayers = async () => {
     if (layerStore.player) {
-      console.log('LAYERPLAYER');
+      console.log('LAYERPLAYER',layerStore.player);
       layerStore.player.start();
     }
   };
@@ -122,7 +122,7 @@ export default function LayerPlayer({
   const changeVolumeValue = (event, newValue) => {
     newValue = Math.round(newValue);
     setGlobalVolume(newValue);
-   layerStore.player.setAllLayersVolume(newValue)
+   layerStore.player.setAllLayersVolume(-40 + newValue)
   };
 
   const changePlaybackRate = (event,newValue) => {
@@ -189,10 +189,10 @@ export default function LayerPlayer({
             <Typography variant='subtitle2' id='modal-edit-title'>
               Edit Layer: {'placeholder'}
             </Typography>
-            <Typography>Volume</Typography>
+            <Typography>Volume: {globalVolume === 40 ? "Max" : globalVolume === 0 ? 'Min' : globalVolume}</Typography>
           <Slider
-            min={-40}
-            max={5}
+            min={0}
+            max={40}
             value={globalVolume}
             onChange={changeVolumeValue}
             aria-label='Volume Slider'

--- a/client/src/components/LayerPlayer.jsx
+++ b/client/src/components/LayerPlayer.jsx
@@ -36,7 +36,7 @@ export default function LayerPlayer({
   const playerRef = useRef(layerStore.player);
   const [allLayersLoaded, setAllLayersLoaded] = useState(false);
   const [globalPitch, setGlobalPitch] = useState(0);
-  const [globalVolume, setGlobalVolume] = useState(0)
+  const [globalVolume, setGlobalVolume] = useState(-20)
   const [globalPlayback,setGlobalPlayback] = useState(1)
 
   const playAllLayers = async () => {
@@ -191,8 +191,8 @@ export default function LayerPlayer({
             </Typography>
             <Typography>Volume</Typography>
           <Slider
-            min={-20}
-            max={20}
+            min={-40}
+            max={5}
             value={globalVolume}
             onChange={changeVolumeValue}
             aria-label='Volume Slider'

--- a/client/src/lib/layer.js
+++ b/client/src/lib/layer.js
@@ -15,8 +15,8 @@ export class Layer {
     this.url = url;
     this.player = new Tone.GrainPlayer(this.url);
     this.player.playbackRate = playbackRate || 1;
+    this.player.detune = pitch || 0;
     this.volume = new Tone.Volume(volume || 0);
-    this.pitchShift = new Tone.PitchShift(pitch || 0);
     this.waveform = new Tone.Waveform();
     this.solo = new Tone.Solo().toDestination();
     this.layerData = layerData;
@@ -24,7 +24,7 @@ export class Layer {
     this.trimFromEnd = trimFromEnd || Infinity;
     this.trimFromStart = trimFromStart || 0;
     this.playbackRate = playbackRate || 1;
-    this._pitch = this.pitchShift.pitch;
+    this._pitch = pitch ||0
     this._mute = false;
     this._solo = false;
     this._volume = this.volume.volume.value;
@@ -33,8 +33,9 @@ export class Layer {
   connect() {
     this.player.connect(this.volume);
     this.player.connect(this.waveform);
-    this.volume.connect(this.pitchShift);
-    this.pitchShift.connect(this.solo);
+
+    this.volume.connect(this.solo)
+
   }
 
   stop() {
@@ -119,11 +120,9 @@ export class Layer {
   changeTrimFromEnd(newValue) {
     this.trimFromEnd = newValue;
   }
-  changePitchValue(newValue) {
-    this.pitchShift.pitch = newValue;
-  }
-  changeDetuneValue(newValue){
 
+  changeDetuneValue(newValue){
+    this._pitch = newValue
     this.player.detune = newValue
   }
   changeVolumeValue(newValue) {
@@ -149,13 +148,12 @@ changePlaybackRate(newValue) {
     this.player.dispose()
     this.waveform.dispose()
     this.volume.dispose()
-    this.pitchShift.dispose()
     this.solo.dispose()
   }
 
   getLayerData() {
     return {
-      pitch: this.pitchShift.pitch,
+      pitch: this.player.detune,
       volume: this.volume.volume.value,
       url: this.url,
       fileName: this.layerData.fileName,

--- a/client/src/lib/layer.js
+++ b/client/src/lib/layer.js
@@ -16,7 +16,7 @@ export class Layer {
     this.player = new Tone.GrainPlayer(this.url);
     this.player.playbackRate = playbackRate || 1;
     this.player.detune = pitch || 0;
-    this.volume = new Tone.Volume(volume || 0);
+    this.volume = new Tone.Volume(volume || -20);
     this.waveform = new Tone.Waveform();
     this.solo = new Tone.Solo().toDestination();
     this.layerData = layerData;


### PR DESCRIPTION

removed Pitch shift  and replaced with Detune. 


Refactored Volume Sliders on layers and global player to display from 0  to 40  

Reset Layer.js  Volume to default to -20  dB,  half of max volume.  

Added conditionals in UI on  LayerPlayer.jsx and LayerEditor.jsx to display Min or Max next to the Volume Typography component if either value is reached. 



