### PR TITLE
Navigate on new track save

### DIFF
--- a/client/src/components/LayerPlayer.jsx
+++ b/client/src/components/LayerPlayer.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import * as Tone from 'tone';
 
 import { useSnackbar } from 'material-ui-snackbar-provider';
@@ -30,6 +31,7 @@ export default function LayerPlayer({
   trackData,
 }) {
   const [layerStore, dispatch] = useLayerStore();
+  const navigate = useNavigate();
   // const allLayersPlayState = useRef('');
   // const allLayersRef = useRef(layerStore.allLayers);
   const snackbar = useSnackbar();
@@ -37,11 +39,11 @@ export default function LayerPlayer({
   const [allLayersLoaded, setAllLayersLoaded] = useState(false);
   const [globalPitch, setGlobalPitch] = useState(0);
   const [globalVolume, setGlobalVolume] = useState(20)
-  const [globalPlayback,setGlobalPlayback] = useState(1)
+  const [globalPlayback, setGlobalPlayback] = useState(1)
 
   const playAllLayers = async () => {
     if (layerStore.player) {
-      console.log('LAYERPLAYER',layerStore.player);
+      console.log('LAYERPLAYER', layerStore.player);
       layerStore.player.start();
     }
   };
@@ -70,8 +72,11 @@ export default function LayerPlayer({
       if (temp.trackName === undefined || temp.trackName === "") {
         snackbar.showMessage(<Alert variant='error'>Please enter a track name</Alert>);
       } else {
-        await saveTrackData(layerStore.player, userId, temp);
+        let id = await saveTrackData(layerStore.player, userId, temp);
         snackbar.showMessage(<Alert variant='success'>Track saved</Alert>);
+        if (!trackId) {
+          navigate(`/edit/${id}`)
+        }
       }
     } catch (error) {
       console.log(error);
@@ -122,16 +127,16 @@ export default function LayerPlayer({
   const changeVolumeValue = (event, newValue) => {
     newValue = Math.round(newValue);
     setGlobalVolume(newValue);
-   layerStore.player.setAllLayersVolume(-40 + newValue)
+    layerStore.player.setAllLayersVolume(-40 + newValue)
   };
 
-  const changePlaybackRate = (event,newValue) => {
+  const changePlaybackRate = (event, newValue) => {
 
-    console.log('nev',newValue)
+    console.log('nev', newValue)
     let newPlayback = Number(event.target.value);
-    console.log('Newpl',newPlayback)
-    newPlayback >=0.5 ? newPlayback = Number.parseFloat(newPlayback).toFixed(2):
-    newPlayback = Number.parseFloat(newPlayback + 0.1).toFixed(2);
+    console.log('Newpl', newPlayback)
+    newPlayback >= 0.5 ? newPlayback = Number.parseFloat(newPlayback).toFixed(2) :
+      newPlayback = Number.parseFloat(newPlayback + 0.1).toFixed(2);
 
     newPlayback = Number(newPlayback);
     setGlobalPlayback(newPlayback)
@@ -190,14 +195,14 @@ export default function LayerPlayer({
               Edit Layer: {'placeholder'}
             </Typography>
             <Typography>Volume: {globalVolume === 40 ? "Max" : globalVolume === 0 ? 'Min' : globalVolume}</Typography>
-          <Slider
-            min={0}
-            max={40}
-            value={globalVolume}
-            onChange={changeVolumeValue}
-            aria-label='Volume Slider'
-            valueLabelDisplay='auto'
-          />
+            <Slider
+              min={0}
+              max={40}
+              value={globalVolume}
+              onChange={changeVolumeValue}
+              aria-label='Volume Slider'
+              valueLabelDisplay='auto'
+            />
             <Typography> Set Track Pitch {globalPitch} </Typography>
             <Slider
               min={-12}

--- a/client/src/utils/database.js
+++ b/client/src/utils/database.js
@@ -34,7 +34,7 @@ export function saveTrackData(player, userId, metadata) {
         ref = doc(collection(db, "tracks"))
         await setDoc(ref, trackData)
       }
-      resolve()
+      resolve(ref.id)
     } catch (error) {
       reject(error)
     }


### PR DESCRIPTION
Updated save function to send back and the track id.

On save if we didn't have an id previously, navigate to the new one. 

Possible future expanded change, navigate the user if they were not the original user. 