### PR TITLE
Navigate on copy save

### DIFF
--- a/client/src/components/LayerPlayer.jsx
+++ b/client/src/components/LayerPlayer.jsx
@@ -74,7 +74,6 @@ export default function LayerPlayer({
       } else {
         let id = await saveTrackData(layerStore.player, userId, temp);
         snackbar.showMessage(<Alert variant='success'>Track saved</Alert>);
-        console.log(`Owner, ${layerStore.player.owner}, userId ${userId}`)
         if (!trackId || (layerStore.player.owner !== userId)) {
           navigate(`/edit/${id}`)
         }

--- a/client/src/components/LayerPlayer.jsx
+++ b/client/src/components/LayerPlayer.jsx
@@ -74,7 +74,8 @@ export default function LayerPlayer({
       } else {
         let id = await saveTrackData(layerStore.player, userId, temp);
         snackbar.showMessage(<Alert variant='success'>Track saved</Alert>);
-        if (!trackId) {
+        console.log(`Owner, ${layerStore.player.owner}, userId ${userId}`)
+        if (!trackId || (layerStore.player.owner !== userId)) {
           navigate(`/edit/${id}`)
         }
       }


### PR DESCRIPTION
# Navigate when the user saves someone else's track. 
Now when a user opens and saves a track that is not theres, it will navigate to the users copy. 

# Changes
Updated the comparison for navigating to also check the owner and userId