### PR TITLE
Bug fix for issue #69

### DIFF
--- a/client/src/components/Editor.jsx
+++ b/client/src/components/Editor.jsx
@@ -18,6 +18,7 @@ import Recorder from './Recorder';
 
 import { getTrackData } from "../utils/database";
 import { getTrackUrls } from "../utils/storage";
+import { Player } from '../lib/player';
 import UserContext from "../context/UserContext";
 import UploadFile from "./UploadFile.jsx";
 
@@ -80,8 +81,12 @@ export default function Editor() {
         setAudioLayers([])
       }
       if (layerStore.player) {
+        // kill the old players audio
         layerStore.player.dispose()
-        dispatch(setPlayer(null))
+        // make a new blank player
+        const newPlayer = new Player();
+        dispatch(setPlayer(newPlayer))
+
       }
     }
   }, [trackId])
@@ -126,7 +131,7 @@ export default function Editor() {
           top: 50,
           maxHeight: '100vh',
           overflow: 'auto'
-          }}
+        }}
         >
           <ImportAduio userId={userData?.user?.uid} currentList={audioLayers} setParentLayers={setAudioLayers} close={handleImportClose} />
         </Box>

--- a/client/src/components/Recorder.jsx
+++ b/client/src/components/Recorder.jsx
@@ -95,7 +95,7 @@ export default function RecorderTone({ currentList, setAudioLayers }) {
       setMicRecorder(recorder);
       setUserMic(mic);
       await mic.open();
-     recorder.start();
+      recorder.start();
       if (playWith && layerStore.player) {
         layerStore.player.start()
       }
@@ -186,7 +186,6 @@ export default function RecorderTone({ currentList, setAudioLayers }) {
 
       // make sure we are not already capped on layers before adding them to the editor
       if ((currentList?.length || 0) < 4) {
-
         setAudioLayers((prevLayers) => {
           if (layerStore.player) {
             layerStore.player.reload([...prevLayers, data])
@@ -243,7 +242,7 @@ export default function RecorderTone({ currentList, setAudioLayers }) {
         clearInterval(updateTimerRef.current)
       }
 
-      if ((micRecorderRef.current !== null) && !(micRecorderRef.current instanceof Blob) && micRecorderRef.current !==undefined) {
+      if ((micRecorderRef.current !== null) && !(micRecorderRef.current instanceof Blob) && micRecorderRef.current !== undefined) {
         micRecorderRef.current.dispose();
       }
       // close mic on stop.

--- a/client/src/lib/player.js
+++ b/client/src/lib/player.js
@@ -10,7 +10,8 @@ export class Player {
     this.isPlaying = false;
     this.id = trackData?.id;
 
-    layersData.forEach((layer, index) => {
+    // if layersData exists, create new layers
+    layersData?.forEach((layer, index) => {
       const newLayer = new Layer({ ...layer, id: index, layerData: layer });
       newLayer.connect();
       this.layers.push(newLayer);
@@ -88,7 +89,7 @@ export class Player {
   setAllLayersPlaybackRate(newValue) {
 
 
-    this.layers.forEach((layer)=>{
+    this.layers.forEach((layer) => {
       layer.changePlaybackRate(newValue)
 
     })
@@ -107,7 +108,7 @@ export class Player {
     });
   }
 
-  setAllLayersGrainSize() {}
+  setAllLayersGrainSize() { }
 
-  setAllLayersReverse() {}
+  setAllLayersReverse() { }
 }


### PR DESCRIPTION
# Bug fix for issue #69 
Issue discovered to be, the player was being dissolved and reset to null. 

We thought we were catching this in the useEffect for layers in layerPlayer but this useEffect runs after page updates in the HTML. So, the layers were trying to render into HTML before a player was instantiated.

Creating a blank player on editor reset fixes this issue. 

# Changes

- Create a blank player on editor reset
- Updated Player.js to accept undefined values and survive. 