### PR TITLE
Adjust trimming

### DIFF
--- a/client/src/components/LayerEditor.jsx
+++ b/client/src/components/LayerEditor.jsx
@@ -234,7 +234,7 @@ export default function LayerEditorCopy({ id, player }) {
           <Typography>Trim From Start</Typography>
           <Slider
             min={0}
-            max={player.duration() / player.playbackRate}
+            max={Number((player.duration() / player.playbackRate).toPrecision(4))}
             value={trimFromStart}
             onChange={trimFromStartTime}
             aria-label='Trim Slider'
@@ -243,7 +243,7 @@ export default function LayerEditorCopy({ id, player }) {
           <Typography>Trim From End</Typography>
           <Slider
             min={0}
-            max={player.duration() / player.playbackRate}
+            max={Number((player.duration() / player.playbackRate).toPrecision(4))}
             value={trimFromEnd}
             onChange={trimFromEndTime}
             aria-label='Trim Slider'

--- a/client/src/lib/layer.js
+++ b/client/src/lib/layer.js
@@ -50,11 +50,11 @@ export class Layer {
     this.player
       .sync()
       .start(
-        this.trimFromStart,
-        offset,
-        this.duration() / this.player.playbackRate - offset
+        this.trimFromStart / this.player.playbackRate,
+        offset/ this.player.playbackRate,
+       this.trimFromEnd/ this.player.playbackRate - offset
       )
-      .stop(this.trimFromEnd);
+      .stop(this.trimFromEnd/this.player.playbackRate -offset);
     this.startWaveform();
   }
   startWaveform() {


### PR DESCRIPTION
Refactored  start and stop times  to ensure player only plays to the actual trim value. Changed from player. duration. 


Also  divided trim from start and offset by playback rate as an iteration towards preserving trim value times.  

Changed display on trim sliders to  show only   the value  plus 2 decimals when playback rate is changed. 