### PR TITLE
Bug fix for #81

### DIFF
--- a/client/src/components/SignIn.jsx
+++ b/client/src/components/SignIn.jsx
@@ -13,7 +13,7 @@ export default function SignIn({ navigate }) {
     const auth = getAuth();
     signInWithEmailAndPassword(auth, formEmail, formPassword)
       .then((userCredential) => {
-        toast.custom(<Alert variant='filled' severity="success" color='primary'>{`Welcome, ${userCredential.user.displayName}`}</Alert>)
+        toast.custom(<Alert variant='filled' severity="success" color='primary'>Welcome!</Alert>)
         navigate('/dashboard');
       })
       .catch((error) => {


### PR DESCRIPTION
# Bug fix for #81 , 
Toast message is showing null for displayName property in toast message on email signin

# Changes
Removed the empty displayName user property from the interpolated string in the toast success message